### PR TITLE
Updated the thread context key to _opendistro_security_user_info

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ group 'com.amazon.opendistroforelasticsearch.commons'
 
 sourceCompatibility = 1.8
 
-version = "${opendistroVersion}.1"
+version = "${opendistroVersion}.2"
 
 apply plugin: 'java'
 apply plugin: 'jacoco'

--- a/src/main/java/com/amazon/opendistroforelasticsearch/commons/ConfigConstants.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/commons/ConfigConstants.java
@@ -36,7 +36,4 @@ public class ConfigConstants {
     public static final String OPENDISTRO_SECURITY_USE_INJECTED_USER_FOR_PLUGINS = "opendistro_security_use_injected_user_for_plugins";
     public static final String OPENDISTRO_SECURITY_SSL_HTTP_ENABLED = "opendistro_security.ssl.http.enabled";
     public static final String OPENDISTRO_SECURITY_USER_INFO_THREAD_CONTEXT = "_opendistro_security_user_info";
-
-    @Deprecated
-    public static final String OPENDISTRO_SECURITY_USER_AND_ROLES = OPENDISTRO_SECURITY_USER_INFO_THREAD_CONTEXT;
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/commons/ConfigConstants.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/commons/ConfigConstants.java
@@ -35,5 +35,8 @@ public class ConfigConstants {
     public static final String INJECTED_USER = "injected_user";
     public static final String OPENDISTRO_SECURITY_USE_INJECTED_USER_FOR_PLUGINS = "opendistro_security_use_injected_user_for_plugins";
     public static final String OPENDISTRO_SECURITY_SSL_HTTP_ENABLED = "opendistro_security.ssl.http.enabled";
-    public static final String OPENDISTRO_SECURITY_USER_AND_ROLES = "_opendistro_security_user_and_roles";
+    public static final String OPENDISTRO_SECURITY_USER_INFO_THREAD_CONTEXT = "_opendistro_security_user_info";
+
+    @Deprecated
+    public static final String OPENDISTRO_SECURITY_USER_AND_ROLES = OPENDISTRO_SECURITY_USER_INFO_THREAD_CONTEXT;
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/commons/authuser/UserTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/commons/authuser/UserTest.java
@@ -15,7 +15,7 @@
 
 package com.amazon.opendistroforelasticsearch.commons.authuser;
 
-import static com.amazon.opendistroforelasticsearch.commons.ConfigConstants.OPENDISTRO_SECURITY_USER_AND_ROLES;
+import static com.amazon.opendistroforelasticsearch.commons.ConfigConstants.OPENDISTRO_SECURITY_USER_INFO_THREAD_CONTEXT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -122,8 +122,8 @@ public class UserTest {
     @Test
     public void testParseUserString() {
         ThreadContext tc = new ThreadContext(Settings.EMPTY);
-        tc.putTransient("user_roles_string", "myuser|bckrole1,bckrol2|role1,role2|myTenant");
-        String str = tc.getTransient("user_roles_string");
+        tc.putTransient(OPENDISTRO_SECURITY_USER_INFO_THREAD_CONTEXT, "myuser|bckrole1,bckrol2|role1,role2|myTenant");
+        String str = tc.getTransient(OPENDISTRO_SECURITY_USER_INFO_THREAD_CONTEXT);
         User user = User.parse(str);
 
         assertEquals("myuser", user.getName());
@@ -137,7 +137,7 @@ public class UserTest {
     @Test
     public void testParseUserStringEmpty() {
         ThreadContext tc = new ThreadContext(Settings.EMPTY);
-        String str = tc.getTransient(OPENDISTRO_SECURITY_USER_AND_ROLES);
+        String str = tc.getTransient(OPENDISTRO_SECURITY_USER_INFO_THREAD_CONTEXT);
         User user = User.parse(str);
         assertEquals(null, user);
     }
@@ -145,8 +145,8 @@ public class UserTest {
     @Test
     public void testParseUserStringName() {
         ThreadContext tc = new ThreadContext(Settings.EMPTY);
-        tc.putTransient(OPENDISTRO_SECURITY_USER_AND_ROLES, "myuser||");
-        String str = tc.getTransient(OPENDISTRO_SECURITY_USER_AND_ROLES);
+        tc.putTransient(OPENDISTRO_SECURITY_USER_INFO_THREAD_CONTEXT, "myuser||");
+        String str = tc.getTransient(OPENDISTRO_SECURITY_USER_INFO_THREAD_CONTEXT);
         User user = User.parse(str);
 
         assertEquals("myuser", user.getName());
@@ -157,8 +157,8 @@ public class UserTest {
     @Test
     public void testParseUserStringNameWithTenant() {
         ThreadContext tc = new ThreadContext(Settings.EMPTY);
-        tc.putTransient(OPENDISTRO_SECURITY_USER_AND_ROLES, "myuser|||myTenant");
-        String str = tc.getTransient(OPENDISTRO_SECURITY_USER_AND_ROLES);
+        tc.putTransient(OPENDISTRO_SECURITY_USER_INFO_THREAD_CONTEXT, "myuser|||myTenant");
+        String str = tc.getTransient(OPENDISTRO_SECURITY_USER_INFO_THREAD_CONTEXT);
         User user = User.parse(str);
 
         assertEquals("myuser", user.getName());
@@ -170,8 +170,8 @@ public class UserTest {
     @Test
     public void testParseUserStringNobackendRoles() {
         ThreadContext tc = new ThreadContext(Settings.EMPTY);
-        tc.putTransient(OPENDISTRO_SECURITY_USER_AND_ROLES, "myuser||role1,role2");
-        String str = tc.getTransient(OPENDISTRO_SECURITY_USER_AND_ROLES);
+        tc.putTransient(OPENDISTRO_SECURITY_USER_INFO_THREAD_CONTEXT, "myuser||role1,role2");
+        String str = tc.getTransient(OPENDISTRO_SECURITY_USER_INFO_THREAD_CONTEXT);
         User user = User.parse(str);
 
         assertEquals("myuser", user.getName());
@@ -182,8 +182,8 @@ public class UserTest {
     @Test
     public void testParseUserStringNoRoles() {
         ThreadContext tc = new ThreadContext(Settings.EMPTY);
-        tc.putTransient(OPENDISTRO_SECURITY_USER_AND_ROLES, "myuser|brole1,brole2|");
-        String str = tc.getTransient(OPENDISTRO_SECURITY_USER_AND_ROLES);
+        tc.putTransient(OPENDISTRO_SECURITY_USER_INFO_THREAD_CONTEXT, "myuser|brole1,brole2|");
+        String str = tc.getTransient(OPENDISTRO_SECURITY_USER_INFO_THREAD_CONTEXT);
         User user = User.parse(str);
 
         assertEquals("myuser", user.getName());
@@ -194,8 +194,8 @@ public class UserTest {
     @Test
     public void testParseUserStringNoRolesWithTenant() {
         ThreadContext tc = new ThreadContext(Settings.EMPTY);
-        tc.putTransient(OPENDISTRO_SECURITY_USER_AND_ROLES, "myuser|brole1,brole2||myTenant");
-        String str = tc.getTransient(OPENDISTRO_SECURITY_USER_AND_ROLES);
+        tc.putTransient(OPENDISTRO_SECURITY_USER_INFO_THREAD_CONTEXT, "myuser|brole1,brole2||myTenant");
+        String str = tc.getTransient(OPENDISTRO_SECURITY_USER_INFO_THREAD_CONTEXT);
         User user = User.parse(str);
 
         assertEquals("myuser", user.getName());
@@ -207,8 +207,8 @@ public class UserTest {
     @Test
     public void testParseUserStringMalformed() {
         ThreadContext tc = new ThreadContext(Settings.EMPTY);
-        tc.putTransient(OPENDISTRO_SECURITY_USER_AND_ROLES, "|backendrole1,backendrole2|role1,role2");
-        String str = tc.getTransient(OPENDISTRO_SECURITY_USER_AND_ROLES);
+        tc.putTransient(OPENDISTRO_SECURITY_USER_INFO_THREAD_CONTEXT, "|backendrole1,backendrole2|role1,role2");
+        String str = tc.getTransient(OPENDISTRO_SECURITY_USER_INFO_THREAD_CONTEXT);
         User user = User.parse(str);
         assertEquals(null, user);
     }


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*
Updated the thread context key to _opendistro_security_user_info

Other changes:
Updated the version number to 1.12.0.2
Renamed OPENDISTRO_SECURITY_USER_AND_ROLES to OPENDISTRO_SECURITY_USER_INFO_THREAD_CONTEXT
Deprecated OPENDISTRO_SECURITY_USER_AND_ROLES (mapped to OPENDISTRO_SECURITY_USER_INFO_THREAD_CONTEXT)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
