### PR TITLE
Revert Elasticsearch 7.10 changes and Updated version to '1.11.1.0'

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,8 +16,8 @@
 buildscript {
     ext {
         es_group = "org.elasticsearch"
-        es_version = '7.10.0'
-        opendistroVersion = '1.12.0'
+        es_version = '7.9.1'
+        opendistroVersion = '1.11.0'
     }
 
     repositories {
@@ -48,7 +48,7 @@ group 'com.amazon.opendistroforelasticsearch.commons'
 
 sourceCompatibility = 1.8
 
-version = "${opendistroVersion}.2"
+version = "${opendistroVersion}.1"
 
 apply plugin: 'java'
 apply plugin: 'jacoco'

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
     ext {
         es_group = "org.elasticsearch"
         es_version = '7.9.1'
-        opendistroVersion = '1.11.0'
+        opendistroVersion = '1.11.1'
     }
 
     repositories {
@@ -48,7 +48,7 @@ group 'com.amazon.opendistroforelasticsearch.commons'
 
 sourceCompatibility = 1.8
 
-version = "${opendistroVersion}.1"
+version = "${opendistroVersion}.0"
 
 apply plugin: 'java'
 apply plugin: 'jacoco'

--- a/src/main/java/com/amazon/opendistroforelasticsearch/commons/authuser/User.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/commons/authuser/User.java
@@ -126,7 +126,7 @@ final public class User implements Writeable, ToXContent {
         List<String> customAttNames = new ArrayList<>();
         String requestedTenant = null;
 
-        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
+        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser::getTokenLocation);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
             String fieldName = parser.currentName();
             parser.nextToken();
@@ -135,19 +135,19 @@ final public class User implements Writeable, ToXContent {
                     name = parser.text();
                     break;
                 case BACKEND_ROLES_FIELD:
-                    ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.currentToken(), parser);
+                    ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.currentToken(), parser::getTokenLocation);
                     while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
                         backendRoles.add(parser.text());
                     }
                     break;
                 case ROLES_FIELD:
-                    ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.currentToken(), parser);
+                    ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.currentToken(), parser::getTokenLocation);
                     while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
                         roles.add(parser.text());
                     }
                     break;
                 case CUSTOM_ATTRIBUTE_NAMES_FIELD:
-                    ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.currentToken(), parser);
+                    ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.currentToken(), parser::getTokenLocation);
                     while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
                         customAttNames.add(parser.text());
                     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Revert "upgrade for Elasticsearch 7.10.0 (#10)"
Updated version to '1.11.1.0'

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
