### PR TITLE
Remove unused log4j-1.2.12

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,6 @@ apply plugin: 'com.github.johnrengelman.shadow'
 
 dependencies {
     compileOnly "org.elasticsearch.client:elasticsearch-rest-high-level-client:${es_version}"
-    compileOnly group: 'log4j', name: 'log4j', version: '1.2.12'
     testCompile "org.elasticsearch.test:framework:${es_version}"
     testCompile group: 'junit', name: 'junit', version: '4.12'
 }


### PR DESCRIPTION
*Issue #, if available:*
Remove unused log4j-1.2.12

*Description of changes:*
Remove unused log4j-1.2.12

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
